### PR TITLE
Fix templates for filenames with spaces

### DIFF
--- a/lib/dcc.js
+++ b/lib/dcc.js
@@ -20,10 +20,10 @@ const netUtil = require("./net-util");
 const Chat = require("./chat").Chat;
 const parse = require("./parser").parse;
 
-const send_template = "DCC SEND {filename} {addr} {port} {length}";
+const send_template = "DCC SEND \"{filename}\" {addr} {port} {length}";
 const chat_template = "DCC CHAT chat {addr} {port}";
-const accept_template = "DCC ACCEPT {filename} {port} {position}";
-const resume_template = "DCC RESUME {filename} {port} {position}";
+const accept_template = "DCC ACCEPT \"{filename}\" {port} {position}";
+const resume_template = "DCC RESUME \"{filename}\" {port} {position}";
 
 
 const DCC = module.exports = function (client, options) {

--- a/test/dcc.test.js
+++ b/test/dcc.test.js
@@ -372,7 +372,7 @@ describe("DCC", () => {
         });
         it("should call irc.Client.ctcp (with position)", () => {
             var fakeCB = () => { };
-            var expected = ["nick", "privmsg", "DCC RESUME filename 2000 1234"];
+            var expected = ["nick", "privmsg", "DCC RESUME \"filename\" 2000 1234"];
             var dcc = new DCC(fakeClient, { localAddress: "0.0.0.0" });
             dcc.acceptFile("nick", "192.168.1.100", 2000, "filename", 1234567, 1234, fakeCB);
             assert.deepEqual(fakeClient.ctcp.lastCall.args, expected);
@@ -528,7 +528,7 @@ describe("DCC", () => {
             });
             assert.deepEqual(
                 fakeClient.ctcp.lastCall.args,
-                ["to", "privmsg", "DCC SEND filename 3232235876 2000 0"]
+                ["to", "privmsg", "DCC SEND \"filename\" 3232235876 2000 0"]
             );
         });
         it("should resume", (done) => {
@@ -555,7 +555,7 @@ describe("DCC", () => {
             });
             assert.deepEqual(
                 fakeClient.ctcp.lastCall.args,
-                ["to", "privmsg", "DCC ACCEPT filename 2000 50"]
+                ["to", "privmsg", "DCC ACCEPT \"filename\" 2000 50"]
             );
         });
         it("should callback with pos == 50", (done) => {


### PR DESCRIPTION
This was causing me issues when I was trying to resume the download of a file with spaces